### PR TITLE
feat: Add user heartbeating to kill idle connections

### DIFF
--- a/server/src/handler/board.rs
+++ b/server/src/handler/board.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use actix_web::{
     body::BoxBody,
     http::{header::ContentType, StatusCode},
@@ -84,6 +86,7 @@ pub async fn connect(
             name: user.name,
             color: user.color,
             addr: space.clone(),
+            heartbeat: Instant::now(),
         },
         &req,
         stream,


### PR DESCRIPTION
POC to periodically ping the client and reset a user heartbeat. If the hearbeat is stale; consider this connection idle. This would theoretically deal with users who do not gracefully send a Disconnect message