### PR TITLE
fix: ensure non agones setup compiles and run cargo fmt and fix high prio cargo clippy warnings

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,24 @@
+name: Server
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check Server
+      working-directory: ./server
+      run: cargo check --verbose
+    - name: Run tests
+      working-directory: ./server
+      run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.kpt-pipeline

--- a/client/api/auth/securePageLoad.ts
+++ b/client/api/auth/securePageLoad.ts
@@ -7,7 +7,7 @@ import { getUser, User } from "api/user";
 export type SecurityProps = {
   props: {
     signedUp: boolean;
-    user?: User;
+    user: User | null;
   };
 };
 
@@ -24,6 +24,7 @@ export const securePageLoad = async (
       return {
         props: {
           signedUp: false,
+          user: null
         },
       };
     }
@@ -41,6 +42,7 @@ export const securePageLoad = async (
       return {
         props: {
           signedUp: false,
+          user: null
         },
       };
     }
@@ -49,6 +51,7 @@ export const securePageLoad = async (
   return {
     props: {
       signedUp: false,
+      user: null
     },
   };
 };

--- a/server/src/board/registry.rs
+++ b/server/src/board/registry.rs
@@ -12,14 +12,14 @@ use super::{
 #[derive(Debug)]
 pub struct Registry {
     spaces: DashMap<space::ID, Addr<Space>>,
-    space_callback: Sender<BoardEvent>
+    space_callback: Sender<BoardEvent>,
 }
 
 impl Registry {
     pub fn new(space_callback: Sender<BoardEvent>) -> Registry {
         Registry {
             spaces: Default::default(),
-            space_callback
+            space_callback,
         }
     }
 
@@ -29,11 +29,13 @@ impl Registry {
         }
 
         let space = Space::new(id, self.space_callback.clone()).start();
-        let _ = self.space_callback.send(BoardEvent::BoardLoaded { id })
+        let _ = self
+            .space_callback
+            .send(BoardEvent::BoardLoaded { id })
             .await;
 
         self.spaces.insert(id, space.clone());
-        return space;
+        space
     }
 
     pub async fn get_space_info(&self, space_id: space::ID) -> Option<SpaceInfo> {

--- a/server/src/board/storage.rs
+++ b/server/src/board/storage.rs
@@ -82,7 +82,7 @@ impl Service {
     }
 
     fn chat_history(&self) -> Vec<ChatMessage> {
-        self.chat.iter().cloned().collect()
+        self.chat.to_vec()
     }
 
     fn drawings(&self) -> Vec<DrawnLine> {

--- a/server/src/gameserver/healthcheck.rs
+++ b/server/src/gameserver/healthcheck.rs
@@ -1,17 +1,17 @@
 use std::time::Duration;
-
 use tokio::{sync::oneshot, task};
 
-#[cfg(feature = "agones_sdk")]
+
 pub struct HealthChecker {
-    _sender: oneshot::Sender<()>
+    _sender: oneshot::Sender<()>,
 }
 
-#[cfg(feature = "agones_sdk")]
 impl HealthChecker {
     pub fn new(sdk: &agones::Sdk) -> HealthChecker {
         log::info!("Starting health check via agones...");
-        HealthChecker { _sender: HealthChecker::create_channel(sdk) }
+        HealthChecker {
+            _sender: HealthChecker::create_channel(sdk),
+        }
     }
 
     fn create_channel(sdk: &agones::Sdk) -> oneshot::Sender<()> {

--- a/server/src/gameserver/mod.rs
+++ b/server/src/gameserver/mod.rs
@@ -3,9 +3,12 @@
 //! utilites for managing the gameserver
 //!
 
-mod manager;
+#[cfg(feature = "agones_sdk")]
 mod healthcheck;
+#[cfg(feature = "agones_sdk")]
 mod watcher;
 
-pub use self::manager::Manager;
+mod manager;
+
 pub use self::manager::BoardEvent;
+pub use self::manager::Manager;

--- a/server/src/gameserver/watcher.rs
+++ b/server/src/gameserver/watcher.rs
@@ -1,15 +1,15 @@
 use tokio::{sync::oneshot, task};
 
-#[cfg(feature = "agones_sdk")]
 pub struct Watcher {
-    _watcher: oneshot::Sender<()>
+    _watcher: oneshot::Sender<()>,
 }
 
-#[cfg(feature = "agones_sdk")]
 impl Watcher {
     pub fn new(sdk: &agones::Sdk) -> Watcher {
         log::info!("Watching gameserver state changes...");
-        Watcher { _watcher: Watcher::create_channel(sdk) }
+        Watcher {
+            _watcher: Watcher::create_channel(sdk),
+        }
     }
 
     fn create_channel(sdk: &agones::Sdk) -> oneshot::Sender<()> {
@@ -41,7 +41,7 @@ impl Watcher {
                             break;
                         }
                     }
-                }
+                },
             }
         });
 

--- a/server/src/handler/board.rs
+++ b/server/src/handler/board.rs
@@ -76,11 +76,10 @@ pub async fn connect(
 ) -> Result<HttpResponse, Error> {
     let user = get_user(&req, users)?;
     let space_id = get_space_id(&req)?;
-    let space = spaces.get_or_create(space_id)
-        .await;
+    let space = spaces.get_or_create(space_id).await;
 
     ws::start(
-        User::new(user.id.into(), user.name, user.color, space.clone()),
+        User::new(user.id.into(), user.name, user.color, space),
         &req,
         stream,
     )

--- a/server/src/user/registry.rs
+++ b/server/src/user/registry.rs
@@ -28,10 +28,7 @@ impl Registry {
     }
 
     pub fn get(&self, id: u16) -> Option<Participant> {
-        match self.users.get(&id) {
-            Some(entry) => Some(entry.value().to_owned()),
-            None => None,
-        }
+        self.users.get(&id).map(|entry| entry.value().to_owned())
     }
 
     pub fn get_all(&self) -> Vec<Participant> {


### PR DESCRIPTION
this pr ensures the local setup of the project running on a host outside of k8s/agones still builds. it also applies cargo fmt and addresses the most significant cargo clippy warnings in the project. 
in addition, it addresses a next.js warning that is logged when serializing the board page props in the event there is no valid user